### PR TITLE
Es 105998

### DIFF
--- a/pex/pep425.py
+++ b/pex/pep425.py
@@ -25,6 +25,24 @@ class PEP425Extras(object):
     invalid_tag = ValueError('invalid macosx tag: %s' % platform_tag)
     if not cls.is_macosx_platform(platform_tag):
       raise invalid_tag
+
+    # HACK: macOS 11 has tags like macosx_11_x86_64
+    # and this breaks this parsing because it assumes the minor version
+    # is present on the tag
+    segments = platform_tag.split('_', 2)
+    if len(segments) != 3:
+        raise invalid_tag
+    if segments[0] != 'macosx':
+      raise invalid_tag
+    # Minor is not present
+    if not segments[2].isdigit():
+        try:
+            major, minor = int(segments[1]), 0
+            platform = segments[2]
+        except ValueError:
+            raise invalid_tag
+        return major, minor, platform
+
     segments = platform_tag.split('_', 3)
     if len(segments) != 4:
       raise invalid_tag


### PR DESCRIPTION
I download the zip file from github from my branch

then uploaded to our s3 somewhere:
```
$ bazel/upload_artifact_presigned_http.sh ~/Downloads/pex-ES-105998.zip -d gabriel.russo
NOT Using Bazel Cache
(19:30:23) INFO: Current date is 2021-05-27
(19:30:23) INFO: Analyzed target //bazel/artifacts:upload (0 packages loaded, 0 targets configured).
(19:30:23) INFO: Found 1 target...
Target //bazel/artifacts:upload up-to-date:
  bazel-bin/bazel/artifacts/upload
(19:30:23) INFO: Elapsed time: 0.401s, Critical Path: 0.22s
(19:30:23) INFO: 0 processes.
(19:30:23) INFO: Build completed successfully, 1 total action
http_file(
  name = "pex-ES-105998.zip",
  url = "https://databricks-mvn.s3.amazonaws.com/gabriel.russo/pex-ES-105998.zip?AWSAccessKeyId=AKIAJLF6DMKWZKIYMPAQ&Expires=1937500227&Signature=iOzTZRnc0pDNb6iqTu8HxtrcDrk%3D",
  sha256 = "315d58c90234c97436abd3ca440159a41d2cb16c91c27dace863f1777ca6bd73"
)
```

changed the universe reference:
```
diff --git a/WORKSPACE b/WORKSPACE
index fe98aaac8ec..72020fcfb8e 100755
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,10 +121,10 @@ artifact_uploader_deps()
 http_archive(
     name = "pex_db_fork",
     urls = [
-        "https://databricks-mvn.s3.amazonaws.com/pex-archive/pex-1.2.2-db.0.zip?AWSAccessKeyId=AKIAJLF6DMKWZKIYMPAQ&Expires=1825809560&Signature=BvtvsLw1sAxXgrntQi2nuOAj98k%3D",
+        "https://databricks-mvn.s3.amazonaws.com/gabriel.russo/pex-ES-105998.zip?AWSAccessKeyId=AKIAJLF6DMKWZKIYMPAQ&Expires=1937500227&Signature=iOzTZRnc0pDNb6iqTu8HxtrcDrk%3D",
     ],
-    sha256 = "34adbeecdec7f3f8cb4453b7c1c8375bc7fd047267f449b958b3111c722cad2a",
-    strip_prefix = "pex-1.2.2-db.0",
+    sha256 = "315d58c90234c97436abd3ca440159a41d2cb16c91c27dace863f1777ca6bd73",
+    strip_prefix = "pex-ES-105998",
     build_file_content = """
 py_library(
   name = "pex",
```

Ran a clean build and asked for someone to test it for me on big sur 11. Waiting for results.

This breaks PEX binaries on 10.15 though. There is a bug because I can't really use `isdigit`. We need a better way to verify if the minor version is not present, it's definitely not a hard problem because we can assume a well defined format.
