### PR TITLE
changes needed for this to work with newer versions of python

### DIFF
--- a/pex/base.py
+++ b/pex/base.py
@@ -3,7 +3,12 @@
 
 from __future__ import absolute_import
 
-from collections import Iterable
+try:
+    # Python 3
+    from collections.abc import Iterable
+except ImportError:
+    # Python 2.7
+    from collections import Iterable
 
 from pkg_resources import Requirement
 

--- a/pex/finders.py
+++ b/pex/finders.py
@@ -22,9 +22,9 @@ import zipimport
 import pkg_resources
 
 if sys.version_info >= (3, 3) and sys.implementation.name == "cpython":
-  import importlib._bootstrap as importlib_bootstrap
+  import importlib.machinery as importlib_machinery
 else:
-  importlib_bootstrap = None
+  importlib_machinery = None
 
 
 class ChainedFinder(object):
@@ -213,8 +213,8 @@ def register_finders():
   # append the wheel finder
   _add_finder(pkgutil.ImpImporter, find_wheels_on_path)
 
-  if importlib_bootstrap is not None:
-    _add_finder(importlib_bootstrap.FileFinder, find_wheels_on_path)
+  if importlib_machinery is not None:
+    _add_finder(importlib_machinery.FileFinder, find_wheels_on_path)
 
   __PREVIOUS_FINDER = previous_finder
 

--- a/pex/link.py
+++ b/pex/link.py
@@ -5,7 +5,12 @@ from __future__ import absolute_import
 
 import os
 import posixpath
-from collections import Iterable
+try:
+    # Python 3
+    from collections.abc import Iterable
+except ImportError:
+    # Python 2.7
+    from collections import Iterable
 
 from .compatibility import string as compatible_string
 from .compatibility import PY3, WINDOWS, pathname2url, url2pathname

--- a/pex/orderedset.py
+++ b/pex/orderedset.py
@@ -8,10 +8,15 @@
 # modifications
 #
 
-import collections
+try:
+    # Python 3
+    from collections.abc import MutableSet as CollectionsMutableSet
+except ImportError:
+    # Python 2.7
+    from collections import MutableSet as CollectionsMutableSet
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(CollectionsMutableSet):
   KEY, PREV, NEXT = range(3)
 
   def __init__(self, iterable=None):

--- a/pex/pep425.py
+++ b/pex/pep425.py
@@ -99,7 +99,7 @@ class PEP425(object):  # noqa
     """
     # Predict soabi for reasonable interpreters.  This is technically wrong but essentially right.
     abis = []
-    if impl == 'cp' and version.startswith('3'):
+    if impl == 'cp':
       abis.extend([
         'cp%s' % version,
         'cp%sdmu' % version, 'cp%sdm' % version, 'cp%sdu' % version, 'cp%sd' % version,


### PR DESCRIPTION
This includes some python3 compatibility changes, and some changes to get the supported abi tags recognized properly when running under `cp2x`