### PR TITLE
[ES-407859] Fix macOS platform tag parsing

### DIFF
--- a/pex/pep425.py
+++ b/pex/pep425.py
@@ -26,18 +26,20 @@ class PEP425Extras(object):
     if not cls.is_macosx_platform(platform_tag):
       raise invalid_tag
     segments = platform_tag.split('_', 3)
-    if len(segments) != 4:
+    if len(segments) < 3:
       raise invalid_tag
     if segments[0] != 'macosx':
       raise invalid_tag
     try:
-      major= int(segments[1])
+      major = int(segments[1])
       try:
         minor = int(segments[2])
         platform = segments[3]
       except ValueError:
         minor = 0
-        platform = segments[2]
+        platform = "_".join(segments[2:])
+      except IndexError:
+        raise invalid_tag
     except ValueError:
       raise invalid_tag
     return major, minor, platform

--- a/tests/test_pep425.py
+++ b/tests/test_pep425.py
@@ -27,15 +27,16 @@ def test_platform_iterator():
       'macosx_10_0_x86_64',
       'macosx_10_0_universal',
   ])
+  assert PEP425Extras.parse_macosx_tag('macosx_12_arm64') == (12, 0, "arm64")
+  assert PEP425Extras.parse_macosx_tag('macosx_12_x86_64') == (12, 0, "x86_64")
+  assert PEP425Extras.parse_macosx_tag('macosx_12_1_arm64') == (12, 1, "arm64")
+  assert PEP425Extras.parse_macosx_tag('macosx_12_1_x86_64') == (12, 1, "x86_64")
 
   with pytest.raises(ValueError):
     list(PEP425Extras.platform_iterator('macosx_10'))
 
   with pytest.raises(ValueError):
     list(PEP425Extras.platform_iterator('macosx_10_0'))
-
-  with pytest.raises(ValueError):
-    list(PEP425Extras.platform_iterator('macosx_9_x86_64'))
 
 
 def test_iter_supported_tags():

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skip_missing_interpreters = True
 minversion = 1.8
 envlist =
-	py{py,27,36}-requests,style,isort-check
+	py{27,38}-requests
 
 [testenv]
 commands =


### PR DESCRIPTION
The macOS tag parsing was buggy. It would fail to parse `macosx_12_arm64` which is a valid tag.
Now it hopefully parses the tags properly. 

We had a similar problem in the past: https://databricks.atlassian.net/browse/ES-105998

Back then, things more or less worked because the platform itself had an underscore (x86_64), so there were 4 segments.

## Tests
`tox tests/test_pep425.py` 