### PR TITLE
Make PEX binaries deterministic

### DIFF
--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -264,9 +264,9 @@ class PexInfo(object):
 
   def dump(self, **kwargs):
     pex_info_copy = self._pex_info.copy()
-    pex_info_copy['requirements'] = list(self._requirements)
+    pex_info_copy['requirements'] = sorted(list(self._requirements))
     pex_info_copy['distributions'] = self._distributions.copy()
-    return json.dumps(pex_info_copy, **kwargs)
+    return json.dumps(pex_info_copy, sort_keys=True, **kwargs)
 
   def copy(self):
     return self.from_json(self.dump())

--- a/tests/test_pex_info.py
+++ b/tests/test_pex_info.py
@@ -39,7 +39,7 @@ def test_backwards_incompatible_pex_info():
 
 
 def assert_same_info(expected, actual):
-  assert expected.dump(sort_keys=True) == actual.dump(sort_keys=True)
+  assert expected.dump() == actual.dump()
 
 
 def test_from_empty_env():


### PR DESCRIPTION
The PEXINFO file was non deterministic because it was just blindly serializing sets. Now we make sure to pass `sort_keys` to `json.dumps` and also sort the requirements.

See https://docs.google.com/document/d/1x7Ydp8WYyNszZBbFTSA2R2pTMVZsgCHH8_vG9QCRaPY/edit#heading=h.svyy8w3thizy

## tests

I tested this by build pex over and over and making sure the hash was the same:

```
$ bazel clean && USE_BAZEL_CACHE=false bazel build --override_repository=pex_db_fork=/home/gabriel.russo/pex //manager:mysql_console && shasum bazel-bin/manager/mysql_console
110016587a59e6834e244d429622a50422e0b67d
```

Without these changes, the SHA changes almost every time.

I can also confirm the pex still executes

also ran `tox` on the pex repo and all tests passed