### PR TITLE
Properly check for macOS wheels compatibility

### DIFF
--- a/pex/package.py
+++ b/pex/package.py
@@ -219,8 +219,7 @@ class WheelPackage(Package):
     for py in self._py_tag.split('.'):
       for abi in self._abi_tag.split('.'):
         for arch in self._arch_tag.split('.'):
-          for real_arch in PEP425Extras.platform_iterator(arch):
-            yield (py, abi, real_arch)
+          yield (py, abi, arch)
 
   def compatible(self, identity, platform=Platform.current()):
     for tag in PEP425.iter_supported_tags(identity, platform):


### PR DESCRIPTION
`PEP425Extras.platform_iterator(arch)` returns `arch` for linux and a list of all supported platforms for macOS:
https://github.com/databricks/pex/blob/beccac210b8ef2d3685cfbc541881e0a7656bf38/pex/pep425.py#L143-L147

What PEX previously did while resolving what wheels are compatible on macOS is:
- For a wheel, extract its platform tag and list all the platform tags compatible with it 
- For the running platform, list all the platform tags compatible with it

And if those lists intersect, PEX decides they are compatible. Now this makes no sense because for a wheel like `jsonnet_macosx_13_0_arm64.whl`, the tag `macosx_13_universal2` is compatible. `macosx_13_universal2` is also compatible with x86, so you could end up with PEX picking an arm wheel on x86, which obviously causes issues.

Instead we now do something way more sensible:
For the running platform, we list all the compatible tags. (no change in behaviour)
For the wheel, we just keep its tag.

If the wheel matches the list, then we say it's compatible.

**This change only affects macOS**