### PR TITLE
Import abstract base classes from collections.abc instead of collections

### DIFF
--- a/pex/base.py
+++ b/pex/base.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from pkg_resources import Requirement
 

--- a/pex/link.py
+++ b/pex/link.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import os
 import posixpath
-from collections import Iterable
+from collections.abc import Iterable
 
 from .compatibility import string as compatible_string
 from .compatibility import PY3, WINDOWS, pathname2url, url2pathname

--- a/pex/orderedset.py
+++ b/pex/orderedset.py
@@ -11,7 +11,7 @@
 import collections
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
   KEY, PREV, NEXT = range(3)
 
   def __init__(self, iterable=None):


### PR DESCRIPTION
Abstract base classes like Iterable and MutableSet were copied to `collections.abc` from python 3.3 onwards - and then completely removed from base `collections` in python 3.10. Modifying the imports so that it works for 3.10 and above.