### PR TITLE
Make pex recognise py310 wheels

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -182,7 +182,7 @@ class PythonInterpreter(object):
     # NB: OSX ships python binaries named Python so we allow for capital-P.
     re.compile(r'[Pp]ython$'),
 
-    re.compile(r'python[23].[0-9]$'),
+    re.compile(r'python[23]\.[0-9]{1,2}$'),
     re.compile(r'pypy$'),
     re.compile(r'pypy-1.[0-9]$'),
   )

--- a/pex/pep425.py
+++ b/pex/pep425.py
@@ -202,9 +202,8 @@ class PEP425(object):  # noqa
 
     major_version = int(version[0])
     minor_versions = []
-    for minor in range(int(version[1]), -1, -1):
+    for minor in range(int(version[1:]), -1, -1):
       minor_versions.append('%d%d' % (major_version, minor))
-
     platforms = list(PEP425Extras.platform_iterator(cls.translate_platform_to_tag(platform)))
 
     # interpreter specific


### PR DESCRIPTION
1. pep425.py - `version` is a string that looks like `38` or `310` (it does not include patch version). Taking just `version[1]` was forcing py 3.10 to match for 3.1 instead. Including the whole of remaining string as minor version to fix this.
2. intepreter.py - Not exactly sure where this code is used - perhaps not in our flows since we always specify the interpreter - but fixing the regex to match 2 digit minor versions regardless.